### PR TITLE
Fixed curious check state behavior of ModPack

### DIFF
--- a/ModMyFactory/Modpack.cs
+++ b/ModMyFactory/Modpack.cs
@@ -42,8 +42,7 @@ namespace ModMyFactory
             get => _enabled;
             set
             {
-                if (value is null) throw new InvalidOperationException("Cannot set enabled state to null");
-                else SetEnabledState(value.Value);
+                if (value != null) SetEnabledState(value.Value);
             }
         }
 


### PR DESCRIPTION
Clicking checkbox for a mod pack containing multiple mods will set null until turn on checkbox for all mods in the mod pack.
At this time, an exception is raised and the check status is not set correctly. 