### PR TITLE
Fix typo in the settings view model

### DIFF
--- a/ModMyFactoryGUI/ViewModels/SettingsViewModel.cs
+++ b/ModMyFactoryGUI/ViewModels/SettingsViewModel.cs
@@ -323,7 +323,7 @@ namespace ModMyFactoryGUI.ViewModels
 
                 case Location.Custom:
                     ModLocationIsCustom = true;
-                    CustomFactorioLocation = Program.Locations.CustomModPath!;
+                    CustomModLocation = Program.Locations.CustomModPath!;
                     break;
             }
 


### PR DESCRIPTION
Typo caused the Factorio instances location string to be overwritten by the mod location string, and the mod location string to be empty.

Note: the settings were saved correctly and were only corrupted when loading the settings for view/editing.

Note 2: This is a re-do of the pull request opened days ago (https://github.com/Artentus/ModMyFactory2/pull/54), moving the source off of my fork's master branch. Apparently, it is impossible to alter the source branch of a PR :(